### PR TITLE
feature/add argument to change source name

### DIFF
--- a/ddataflow/ddataflow.py
+++ b/ddataflow/ddataflow.py
@@ -228,10 +228,6 @@ $ ddataflow setup_project"""
 
         return base_path + "/" + path.replace("dbfs:/", "")
 
-    def _get_new_table_name(self, name) -> str:
-        overriden_name = name.replace("dwh.", "")
-        return self.project_folder_name + "_" + overriden_name
-
     def name(self, *args, **kwargs):
         """
         A shorthand for source_name

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -57,3 +57,54 @@ def test_temp_table_name():
     assert (
         ddataflow.name("location", disable_view_creation=True) == "unit_tests_location"
     )
+
+def test_temp_table_name_backwards_compatability_dwh_schema():
+
+    config = {
+        "sources_with_default_sampling": ["dwh.location"],
+        "project_folder_name": "unit_tests",
+    }
+
+    ddataflow = DDataflow(**config)
+    ddataflow.disable()
+    # by default do not override
+    assert ddataflow.name("dwh.location", disable_view_creation=True) == "dwh.location"
+    ddataflow.enable()
+    assert (
+        ddataflow.name("dwh.location", disable_view_creation=True) == "unit_tests_location"
+    )
+
+def test_temp_table_name_backwards_compatability_non_dwh_schema():
+
+    config = {
+        "sources_with_default_sampling": ["default.events"],
+        "project_folder_name": "unit_tests",
+    }
+
+    ddataflow = DDataflow(**config)
+    ddataflow.disable()
+    # by default do not override
+    assert ddataflow.name("default.events", disable_view_creation=True) == "default.events"
+    ddataflow.enable()
+    assert (
+        ddataflow.name("default.events", disable_view_creation=True) == "unit_tests_default.events"
+    )
+
+def test_temp_table_name_with_generating_source_name():
+    def create_temp_table_name(name: str, project_folder_name: str) -> str:
+        return f"{project_folder_name}-{name.replace('.', '__')}"
+
+    config = {
+        "sources_with_default_sampling": ["dwh.location"],
+        "project_folder_name": "unit_tests",
+        "generate_source_name": create_temp_table_name,
+    }
+
+    ddataflow = DDataflow(**config)
+    ddataflow.disable()
+    # by default do not override
+    assert ddataflow.name("dwh.location", disable_view_creation=True) == "dwh.location"
+    ddataflow.enable()
+    assert (
+        ddataflow.name("dwh.location", disable_view_creation=True) == "unit_tests-dwh__location"
+    )


### PR DESCRIPTION
### Context
When using DDataFlow with tables inside a specific schema, for example `dwh.magic_table` and `schema_a.table_a` the internal source_name that is used is an invalid name for spark's createOrReplaceTempView, which can't have a schema in place. 

In the codebase this worked out fine for `dwh.` as there is a line removing this from the source_name, creating `magic_name`. However for the second one, `schema_a.table_a`, the schema name is left and there is an error when creating the temporary view.

### What was done
The idea of an update using a functional argument came from @steven-mi. This would be a new option parameter and would replace `_get_table_name`. The default for new argument is the old `_get_table_name` to allow backwards compatibility with anyone using the older versions of DDataFlow. 

### Notes
A better default function for `generate_name_source` would be something like the following:
```python
def generate_name_source(name: str, project_folder_name: str) -> str:
    return f"{project_folder_name}-{name.replace('.', '__')}"
```

Input: Maybe a better name than `generate_name_source` could happen. Perhaps `generate_temp_table_name`, or something similar.

### Testing
Added one test for checking new functionality and two tests to check original functionality still works. 