### PR TITLE
Support s3 path and set default db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.13
+
+- Support s3 path and default database
+
 # 1.1.9
 
 - Upgrade dependencies due to security

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You can find our documentation in the [docs folder](https://github.com/getyourgu
 ## Features
 
 - Read a subset of our data so to speed up the running of the pipelines during tests
-- Write to a test location our artifacts  so you don't pollute production
+- Write to a test location our artifacts so you don't pollute production
 - Download data for enabling local machine development
 
 Enables to run on the pipelines in the CI

--- a/ddataflow/ddataflow.py
+++ b/ddataflow/ddataflow.py
@@ -36,6 +36,7 @@ class DDataflow:
         sources_with_default_sampling: Optional[List[str]] = None,
         snapshot_path: Optional[str] = None,
         default_sampler: Optional[dict] = None,
+        default_database: Optional[str] = None,
     ):
         """
         Initialize the dataflow object.
@@ -52,6 +53,8 @@ class DDataflow:
          options to pass to the default sampler
         sources_with_default_sampling:
          if you have tables you want to have by default and dont want to sample them first
+        default_database:
+            name of the default database. If ddataflow is enabled, a test db will be created and used.
         sources_with_default_sampling :
          Deprecated: use sources with default_sampling=True instead
          if you have tables you want to have by default and dont want to sample them first
@@ -101,6 +104,9 @@ class DDataflow:
         self.save_sampled_data_sources = Sampler(
             self._snapshot_path, self._data_sources
         ).save_sampled_data_sources
+
+        if default_database:
+            self.set_up_database(default_database)
 
     @staticmethod
     def setup_project():
@@ -238,13 +244,16 @@ $ ddataflow setup_project"""
 
         return base_path + "/" + path
 
-    def set_up_database(self, db_name: str, spark):
+    def set_up_database(self, db_name: str):
         """
         Perform USE $DATABASE query to set up a default database.
         If ddataflow is enabled, use a test db to prevent writing data into production.
         """
+        # rename database if ddataflow is enabled
         if self._ddataflow_enabled:
             db_name = f"ddataflow_{db_name}"
+        # get spark
+        spark = self._get_spark()
         # create db if not exist
         sql = "CREATE DATABASE IF NOT EXISTS {0}".format(db_name)
         spark.sql(sql)

--- a/ddataflow/ddataflow.py
+++ b/ddataflow/ddataflow.py
@@ -224,14 +224,17 @@ $ ddataflow setup_project"""
 
     def path(self, path):
         """
-        returns a deterministic path replacing the real production path with one based on the current environment needs
+        returns a deterministic path replacing the real production path with one based on the current environment needs.
+        Currently support path start with 'dbfs:/' and 's3://'.
         """
         if not self._ddataflow_enabled:
             return path
 
         base_path = self._get_current_environment_data_folder()
 
-        return base_path + "/" + path.replace("dbfs:/", "")
+        for path_prefix in ["dbfs:/", "s3://"]:
+            path = path.replace(path_prefix, "")
+        return base_path + "/" + path
 
     def _get_new_table_name(self, name) -> str:
         overriden_name = name.replace("dwh.", "")


### PR DESCRIPTION
* Previously ddataflow.path() only supports path starting with `dbfs:/`. Since ART and TDP are using mostly the S3 bucket now, make a check for the path starting with `s3://`.
* In the search ranking pipeline refactoring project, we need to create a test database for our end2end test and set it as a [default db](https://github.com/getyourguide/search-ranking-pipeline/blob/31dc19d9b73c788824a3b185e8da20d3fb408f70/search_ranking_pipeline/utilities/database_utils.py#L22-L30). This way all our write command without specifying a db will write directly to the default db. Add an optional attribute to set up a db based on if ddataflow is enable or not.