### PR TITLE
Refine logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.1.14
+
+- Disable logs when DDataflow is not enable. Support setting logger level.
+
 # 1.1.13
 
 - Support s3 path and default database

--- a/ddataflow/ddataflow.py
+++ b/ddataflow/ddataflow.py
@@ -144,7 +144,7 @@ class DDataflow:
         CONFIGURATION_FILE_NAME = "ddataflow_config.py"
 
         current_folder = os.getcwd()
-        logger.info("Loading config from folder", current_folder)
+        logger.debug("Loading config from folder", current_folder)
         config_location = os.path.join(current_folder, CONFIGURATION_FILE_NAME)
 
         if not os.path.exists(config_location):
@@ -424,7 +424,7 @@ $ ddataflow setup_project"""
         else:
             logger.debug(
                 f"""
-                DDataflow is now DISABLED.
+                DDataflow is now DISABLED. So PRODUCTION data will be used and it will write to production tables.
                 Use enable() function or export {self._ENABLE_DDATAFLOW_ENVVARIABLE}=True to enable it.
                 If you are working offline use export ENABLE_OFFLINE_MODE=True instead.
                 """

--- a/ddataflow/ddataflow.py
+++ b/ddataflow/ddataflow.py
@@ -1,4 +1,4 @@
-import logging as logger
+import logging
 import os
 from typing import List, Optional, Union
 
@@ -9,6 +9,9 @@ from ddataflow.exceptions import WriterNotFoundException
 from ddataflow.sampling.default import build_default_sampling_for_sources, DefaultSamplerOptions
 from ddataflow.sampling.sampler import Sampler
 from ddataflow.utils import get_or_create_spark, using_databricks_connect
+
+logger = logging.getLogger(__name__)
+
 
 class DDataflow:
     """

--- a/ddataflow/ddataflow.py
+++ b/ddataflow/ddataflow.py
@@ -11,8 +11,8 @@ from ddataflow.sampling.sampler import Sampler
 from ddataflow.utils import get_or_create_spark, using_databricks_connect
 
 logger = logging.getLogger(__name__)
-console = logging.StreamHandler()
-logger.addHandler(console)
+handler = logging.StreamHandler()
+logger.addHandler(handler)
 
 
 class DDataflow:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "DDataFlow"
-version = "1.1.14"
+version = "1.1.15"
 description = "A tool for end2end data tests"
 authors = ["Data products GYG <engineering.data-products@getyourguide.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "DDataFlow"
-version = "1.1.12"
+version = "1.1.14"
 description = "A tool for end2end data tests"
 authors = ["Data products GYG <engineering.data-products@getyourguide.com>"]
 readme = "README.md"


### PR DESCRIPTION
Add a function to support setting up the logging level. In addition, by default, we now only log messages that help debugging when DDataflow is enabled. See relevant discussion -> [here](https://getyourguide.slack.com/archives/C02KBPF2FTP/p1679506577292229).