### PR TITLE
Change to ubuntu-latest for dependabot automerge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   auto-merge:
     name: Auto merge
-    runs-on: [node-small, self-hosted]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Looks like this is a public repo so we can't use our self-hosted runners for the workflows